### PR TITLE
Readme spell fixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,4 @@ Write here
 ### Check List
 
 - [ ] All test passed
-- [ ] Added test to ensure to fix/exnsure properly.
-
-
+- [ ] Added test to ensure to fix/ensure properly.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Tweak generated files in `your-repo/.github/*` for your project-specific informa
 
 ## Writing Template File
 
-You can see [example direcotry in this repository](exapmle/) for real world examples.
+You can see [example directory in this repository](example/) for real world examples.
 
 `dot-github` looks below template files
 


### PR DESCRIPTION
### Description

Fixing the spelling in the description and link for `example/` in `README.md` and the word "ensure" in `.github/PULL_REQUEST_TEMPLATE.md`
### Check List
- [x] All test passed
- [x] Added test to ensure to fix/ensure properly.
